### PR TITLE
Add AMD support

### DIFF
--- a/src/jquery.countdown.js
+++ b/src/jquery.countdown.js
@@ -23,7 +23,13 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-(function($) {
+(function(factory) {
+  if(typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else {
+    factory(jQuery);
+  }
+}(function($) {
   
   $.fn.countdown = function(toDate, callback) {
     var handlers = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'daysLeft'];
@@ -125,4 +131,4 @@
       start();
     });
   }
-})(jQuery);
+}));


### PR DESCRIPTION
Hi,

This pull add AMD support for the plugin.
It register jquery as a dependency and fallback to the default implementation if there is no AMD defined.

I don't think so much test overhead is necessary for this.
