### PR TITLE
Add Elapsed event in countdown.js

### DIFF
--- a/src/countdown.js
+++ b/src/countdown.js
@@ -75,7 +75,8 @@
           // Swap shot-versions directives
           if(DIRECTIVE_KEY_MAP.hasOwnProperty(directive)) {
             value = DIRECTIVE_KEY_MAP[directive];
-            value = Number(offsetObject[value]);
+            value = (Number(offsetObject[value]) < 0) ?
+              Number(offsetObject[value]) * -1 : Number(offsetObject[value]);
           }
           if(value !== null) {
             // Pluralize
@@ -121,6 +122,7 @@
     this.$el      = $(el);
     this.interval = null;
     this.offset   = {};
+    this.elapsed  = true;
     // Register this instance
     this.instanceNumber = instances.length;
     instances.push(this);
@@ -131,6 +133,7 @@
       this.$el.on('update.countdown', callback);
       this.$el.on('stoped.countdown', callback);
       this.$el.on('finish.countdown', callback);
+      this.$el.on('elapsed.countdown', callback);
     }
     // Set the final date and start
     this.setFinalDate(finalDate);
@@ -177,7 +180,9 @@
       this.totalSecsLeft = this.finalDate.getTime() -
         new Date().getTime(); // In miliseconds
       this.totalSecsLeft = Math.ceil(this.totalSecsLeft / 1000);
-      this.totalSecsLeft = this.totalSecsLeft < 0 ? 0 : this.totalSecsLeft;
+      if (!this.elapsed) {
+        this.totalSecsLeft = this.totalSecsLeft < 0 ? 0 : this.totalSecsLeft;    
+      }
       // Calculate the offsets
       this.offset = {
         seconds   : this.totalSecsLeft % 60,
@@ -190,11 +195,13 @@
         years     : Math.floor(this.totalSecsLeft / 60 / 60 / 24 / 365)
       };
       // Dispatch an event
-      if(this.totalSecsLeft === 0) {
+      if (this.totalSecsLeft < 0 && this.elapsed) {
+        this.dispatchEvent("elapsed");
+      } else if (this.totalSecsLeft === 0) {
         this.stop();
-        this.dispatchEvent('finish');
+        this.dispatchEvent("finish");
       } else {
-        this.dispatchEvent('update');
+        this.dispatchEvent("update");
       }
     },
     dispatchEvent: function(eventName) {


### PR DESCRIPTION
Add the Elapsed Event to the Countdown.
This function is to allow use the countdown to still counting when the event already happened.
