### PR TITLE
remove jquery.countdown.min.js from main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,7 @@
     }
   ],
   "main": [
-    "./dist/jquery.countdown.js",
-    "./dist/jquery.countdown.min.js"
+    "./dist/jquery.countdown.js"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
content of this file is already included (unminified) in jquery.countdown.js
double-listing will cause double-loading the same code
