### PR TITLE
increased flip-effect delay to improve rendering in browsers

### DIFF
--- a/_includes/main-example.html
+++ b/_includes/main-example.html
@@ -73,7 +73,7 @@
           // Wait for a repaint to then flip
           _.delay(function($node) {
             $node.addClass('flip');
-          }, 5, $node);
+          }, 50, $node);
         });
       }
     });


### PR DESCRIPTION
the flip-effect didn't work so well in firefox and ie10.
increasing the delay did improve the flip-effect rendering.