### PR TITLE
Replace http by https links/includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 The Final Countdown Website
 ===========================
 
-jQuery Final Countdown website source code containing the documentation and examples for the plugin. The website is powered by Jekyll and hosted in GitHub Pages at http://hilios.github.io/jQuery.countdown/
+jQuery Final Countdown website source code containing the documentation and examples for the plugin. The website is powered by Jekyll and hosted in GitHub Pages at https://hilios.github.io/jQuery.countdown/
 
 Getting started
 ---------------
 
-Install [Jekyll](http://jekyllrb.com/) on your machine, proceed to your terminal and start the server.
+Install [Jekyll](https://jekyllrb.com/) on your machine, proceed to your terminal and start the server.
 
 ```
 jekyll serve -w -b ''

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name:           The Final Countdown
 nickname:       jQuery.countdown
 plugin_version: 2.1.0
-baseurl:        http://hilios.github.io/jQuery.countdown
+baseurl:        https://hilios.github.io/jQuery.countdown
 highlight:      true
 markdown:       redcarpet
 redcarpet:

--- a/_includes/gh-buttons.html
+++ b/_includes/gh-buttons.html
@@ -1,11 +1,11 @@
 <div class="gh-btns">
   <!-- Follow -->
-  <iframe src="http://ghbtns.com/github-btn.html?user=hilios&type=follow"
+  <iframe src="https://ghbtns.com/github-btn.html?user=hilios&type=follow"
     allowtransparency="true" frameborder="0" scrolling="0" width="120" height="20"></iframe>
   <!-- Watch -->
-  <iframe src="http://ghbtns.com/github-btn.html?user=hilios&repo=jQuery.countdown&type=watch&count=true"
+  <iframe src="https://ghbtns.com/github-btn.html?user=hilios&repo=jQuery.countdown&type=watch&count=true"
     allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
   <!-- Fork -->
-  <iframe src="http://ghbtns.com/github-btn.html?user=hilios&repo=jQuery.countdown&type=fork&count=true"
+  <iframe src="https://ghbtns.com/github-btn.html?user=hilios&repo=jQuery.countdown&type=fork&count=true"
       allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
 </div>

--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -20,7 +20,7 @@
     </a>
   </li>
   <li>
-    <a href="http://plugins.jquery.com/countdown/">
+    <a href="https://plugins.jquery.com/countdown/">
       jQuery Plugins
     </a>
   </li>


### PR DESCRIPTION
This fixes mixed content errors on modern browsers when visiting the page over HTTPS.