### PR TITLE
Fall back to HTTP for broken yahooapis.com

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="//yui.yahooapis.com/pure/0.4.2/pure-min.css">
+  <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.4.2/pure-min.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600,300italic">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Oswald">
   <link rel="stylesheet" href="{{site.baseurl}}/css/syntax.css">


### PR DESCRIPTION
Fixes the protocol-less specification for yahooapis.com, as that page actually did not support HTTPS at all.

Note that this is in principle unrelated to #156 and #157, but only became apparent when visiting the page over HTTPS. The reason it is now triggered is because #156 sets the base URL to use HTTPS, influencing this.