### PR TITLE
Update main.css

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -172,11 +172,11 @@ main [class*="pure-u-"]:last-child article {
   height: 95px;
   width: 65px;
 
-  -webkit-perspective: 500px;
-  -moz-perspective: 500px;
-  -ms-perspective: 500px;
-  -o-perspective: 500px;
-  perspective: 500px;
+  -webkit-perspective: 479px;
+  -moz-perspective: 479px;
+  -ms-perspective: 479px;
+  -o-perspective: 479px;
+  perspective: 479px;
 
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;


### PR DESCRIPTION
Changed the *-perspective settings to 479px to fix the distortion appearing in browsers.
This was reported in #100 and then again in #168 
 I've tested this in Firefox, IE11 and Chrome on Win7, Safari on Mac OS X El Capitan, and Edge on Windows 10. 
It's live on the websites of the company I work for http://www.wardandpartners.co.uk/black-friday-offer/ I'm not trying to sell you anything - honest!
Fix suggested by https://github.com/vilius-g