### PR TITLE
Can modify options after initialization and invoking countdown method

### DIFF
--- a/src/countdown.js
+++ b/src/countdown.js
@@ -284,7 +284,14 @@
           instance.setFinalDate.call(instance, method);
           // Allow plugin to restart after finished
           // Fix issue #38 (thanks to @yaoazhen)
-          instance.start();
+	  if (argumentsArray[1]) {
+	    $.extend(instance.options, argumentsArray[1])
+	    if (instance.options.defer === false)
+	      instance.start();
+	  }
+	  else {
+            instance.start();
+	  }
         } else {
           $.error('Method %s does not exist on jQuery.countdown'
             .replace(/\%s/gi, method));

--- a/src/countdown.js
+++ b/src/countdown.js
@@ -285,7 +285,7 @@
           // Allow plugin to restart after finished
           // Fix issue #38 (thanks to @yaoazhen)
 	  if (argumentsArray[1]) {
-	    $.extend(instance.options, argumentsArray[1])
+	    $.extend(instance.options, argumentsArray[1]);
 	    if (instance.options.defer === false)
 	      instance.start();
 	  }

--- a/src/countdown.js
+++ b/src/countdown.js
@@ -286,8 +286,9 @@
           // Fix issue #38 (thanks to @yaoazhen)
 	  if (argumentsArray[1]) {
 	    $.extend(instance.options, argumentsArray[1]);
-	    if (instance.options.defer === false)
+	    if (instance.options.defer === false) {
 	      instance.start();
+	    }
 	  }
 	  else {
             instance.start();


### PR DESCRIPTION
Hi,
     I don't know if I'm using GitHub properly, but I made the following change to the codebase.  When initializing the countdown timer, I could pass in an object with a defer property such that I could start the timer at a later time.  However, when I invoke the "countdown" method later the timer starts immediately.  I wanted the option such that I could specify that future invocations of the "countdown" method requires an explicit call to "start" to actually start the timer.
     Having made the modification, I might as well provide the user the ability to specify other options when invoking the "countdown" method (specifically, he/she can set the elapse and precision option for the next invocation).