### PR TITLE
allow override of default now() function

### DIFF
--- a/src/countdown.js
+++ b/src/countdown.js
@@ -15,7 +15,8 @@
       defaultOptions  = {
         precision: 100, // 0.1 seconds, used to update the DOM
         elapse: false,
-        defer: false
+        defer: false,
+        getNow: function() { return new Date(); }
       };
   // Miliseconds
   matchers.push(/^[0-9]*$/.source);
@@ -212,7 +213,7 @@
         this.remove();
         return;
       }
-      var now = new Date(),
+      var now = this.options.getNow(),
           newTotalSecsLeft;
       // Create an offset date object
       newTotalSecsLeft = this.finalDate.getTime() - now.getTime(); // Millisecs


### PR DESCRIPTION
This change allows the plugin user to specify a custom function to get the current time.

For my purposes, this allowed me to let the server specify what the client's "current time" would be.